### PR TITLE
docs: Add zstd warning and compression guide with worked examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,11 @@ json-archive videoID.info.json
 
 ### Compression support (as a concession)
 
-While the core design keeps things simple and readable, the tool does work with compressed archives as a practical concession for those who need it. You can read from and write to gzip, deflate, zlib, brotli, and zstd compressed files without special flags.
+While the core design keeps things simple and readable, the tool does work with compressed archives as a practical concession for those who need it. You can read from and write to gzip, deflate, zlib, and brotli compressed files without special flags.
+
+**⚠️ Note:** zstd support is planned but not yet implemented. Use one of the other compression formats for now.
+
+For worked examples and details, see the [compression guide](docs/compression-guide.md).
 
 **Important caveat**: Compressed archives may require rewriting the entire file during updates (depending on the compression format). If your temporary filesystem is full or too small, updates can fail. In that case, manually specify an output destination with `-o` to write the new archive elsewhere.
 
@@ -100,6 +104,7 @@ The tool infers behavior from filenames:
 
 - [Info command](docs/info-command.md) - View archive metadata and observation timeline
 - [State command](docs/state-command.md) - Retrieve JSON state at specific observations
+- [Compression guide](docs/compression-guide.md) - Working with compressed archives
 - [File format specification](docs/file-format-spec.md) - Technical details about the archive format
 
 ### Creating archives

--- a/docs/compression-guide.md
+++ b/docs/compression-guide.md
@@ -1,0 +1,99 @@
+# Compression
+
+Read and write compressed archive files. Compression is detected automatically from the file extension—no special flags needed.
+
+## Supported Formats
+
+| Extension | Format | Status |
+|-----------|--------|--------|
+| `.gz` | gzip | ✅ Working |
+| `.deflate` | deflate | ✅ Working |
+| `.zlib` | zlib | ✅ Working |
+| `.br` | brotli | ✅ Working |
+| `.zst` | zstd | ⚠️ Not working yet |
+
+**Note:** zstd support is planned but not yet implemented. Use one of the other formats for now.
+
+## Example: gzip Workflow
+
+Using the demo files in `docs/demo`:
+
+### Create a compressed archive
+
+```bash
+json-archive -o v1.json.archive.gz v1.json
+```
+
+### Append to a compressed archive
+
+```bash
+json-archive v1.json.archive.gz v2.json
+```
+
+The tool reads the compressed archive, computes deltas, and writes it back compressed.
+
+### Build complete history
+
+```bash
+json-archive -o v1.json.archive.gz v1.json v2.json v3.json
+```
+
+### Inspect the archive
+
+All commands work transparently with compressed archives:
+
+```bash
+# View archive metadata
+json-archive info v1.json.archive.gz
+
+# Get state at specific observation
+json-archive state --index 0 v1.json.archive.gz
+
+# Get latest state
+json-archive state v1.json.archive.gz
+```
+
+### Compare file sizes
+
+```bash
+# Create both versions
+json-archive -o v1.json.archive v1.json v2.json v3.json
+json-archive -o v1.json.archive.gz v1.json v2.json v3.json
+
+# Compare sizes
+ls -la v1.json.archive*
+```
+
+Typical compression ratios are 60-80% for JSON data.
+
+## Caveats
+
+### Temporary filesystem requirements
+
+Compressed archives may require rewriting the entire file during updates. If `/tmp` is full or too small, updates can fail. Specify an output destination with `-o` to write elsewhere:
+
+```bash
+json-archive -o /path/with/space/data.json.archive.gz existing.archive.gz new-data.json
+```
+
+### When to use compression
+
+Use compression when archives are large (hundreds of MB), storage is tight, or you're transferring files over networks.
+
+Stick with uncompressed if you want to grep through archives directly, edit them by hand, or debug their contents.
+
+## Building Without Compression
+
+Compression libraries can be a security vulnerability vector. To build without compression support:
+
+```bash
+cargo install json-archive --no-default-features
+```
+
+The minimal build detects compressed files and gives a clear error explaining you need the full version or manual decompression.
+
+## See Also
+
+- [`json-archive info`](info-command.md) - View archive metadata
+- [`json-archive state`](state-command.md) - Retrieve JSON at specific observations
+- [File Format Specification](file-format-spec.md) - Archive format details

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -172,3 +172,33 @@ json-archive --source "yt-dlp:youtube:dQw4w9WgXcQ" v1.json v2.json v3.json
 **What happens:**
 - Adds source identifier to archive header
 - Helps track where the data came from in complex workflows
+
+## Working with Compressed Archives
+
+This directory includes compressed versions of the demo archive:
+- `v1.json.archive.gz` - gzip compressed
+- `v1.json.archive.zst` - zstd compressed (⚠️ zstd not yet working)
+
+### Using the gzip archive
+
+All commands work transparently with compressed archives:
+
+```bash
+# View archive info
+json-archive info v1.json.archive.gz
+
+# Get the initial state
+json-archive state --index 0 v1.json.archive.gz
+
+# Get latest state
+json-archive state v1.json.archive.gz
+```
+
+### Creating your own compressed archive
+
+```bash
+# Create a gzip-compressed archive from the demo files
+json-archive -o v1.json.archive.gz v1.json v2.json v3.json
+```
+
+For more compression examples, see the [compression guide](../compression-guide.md).


### PR DESCRIPTION
Addresses GitHub issue #1. Adds a note that zstd compression is not yet working, creates a new compression guide page with worked gzip examples, and adds a compression section to the demo README. The changes include:

- Updated README.md to clarify that zstd is planned but not yet implemented
- Created new `docs/compression-guide.md` with complete worked examples showing how to create, append to, and inspect compressed archives
- Added compression section to `docs/demo/README.md` demonstrating usage with the existing demo files

### Trigger Events

<details>
<summary><a href="https://github.com/PeoplesGrocers/json-archive/issues/1">peoplesgrocers/json-archive#1</a></summary>
<br>

**Promptless Research** (1 GitHub Issue)

- [Reviewed PeoplesGrocers/json-archive#1](https://github.com/PeoplesGrocers/json-archive/issues/1)

**Agent Response**

> I've completed all the documentation updates requested in GitHub issue #1. Here's a summary of what I created:
> 
> ## Documentation Suggestion Created
> 
> **Changes made:**
> 
> 1. **Updated `README.md`**
>    - Added a warning that zstd support is planned but not yet implemented
>    - Removed zstd from the list of currently working compression formats
>    - Added a link to the new compression guide in the Documentation section
> 
> 2. **Created `docs/compression-guide.md`** (new file)
>    - Table of supported compression formats with status indicators
>    - Complete worked example showing the gzip workflow:
>      - Creating compressed archives
>      - Appending to compressed archives
>      - Inspecting compressed archives with `info` and `state` commands
>      - Comparing file sizes between compressed and uncompressed
>    - Documented caveats about temporary filesystem requirements
>    - Guidance on when to use (and when not to use) compression
> 
> 3. **Updated `docs/demo/README.md`**
>    - Added section documenting the existing compressed demo files (`v1.json.archive.gz`, `v1.json.archive.zst`)
>    - Included examples showing how to use the gzip archive with the demo files
>    - Noted that the zstd file isn't working yet
>    - Linked to the full compression guide for more examples
> 
> The suggestion is ready for your review.

</details>



---

_Tip: This PR was generated by Promptless via Hacker News. [Book a demo](https://cal.com/team/promptless/15m-discovery-call) to learn how Promptless can keep your docs in sync automatically 📅_